### PR TITLE
Update cabal file to use mtl instead of monads-fd

### DIFF
--- a/digestive-functors/digestive-functors.cabal
+++ b/digestive-functors/digestive-functors.cabal
@@ -28,7 +28,7 @@ Library
                        Text.Digestive.Cli,
                        Text.Digestive
   Build-depends:       base >= 4 && < 5,
-                       monads-fd >= 0.1,
+                       mtl >= 2.0.0.0 && < 3,
                        containers >= 0.3,
                        bytestring >= 0.9,
                        text >= 0.10


### PR DESCRIPTION
Makes digestive-functors more compatible with what's on hackage (monads-fd is now just a re-export of mtl-2).
