### PR TITLE
Untitled

### DIFF
--- a/digestive-functors-snap/src/Text/Digestive/Forms/Snap.hs
+++ b/digestive-functors-snap/src/Text/Digestive/Forms/Snap.hs
@@ -1,6 +1,6 @@
 -- | Module providing a snap backend for the digestive-functors library
 --
-{-# LANGUAGE FlexibleInstances, MultiParamTypeClasses, Rank2Types #-}
+{-# LANGUAGE FlexibleInstances, MultiParamTypeClasses #-}
 module Text.Digestive.Forms.Snap
     ( SnapInput
     , SnapForm
@@ -26,7 +26,7 @@ instance FormInput SnapInput () where
 
 -- | Simplification of the `Form` type, instantiated to Snap
 --
-type SnapForm e v a = (MonadSnap m) => Form m SnapInput e v a
+type SnapForm m = Form m SnapInput
 
 -- | Environment that will fetch input from the parameters parsed by Snap
 --
@@ -45,7 +45,7 @@ snapEnvironment = Environment $ \id' -> do
 --   you will get the actual result
 --
 eitherSnapForm :: (MonadSnap m)
-               => SnapForm e v a     -- ^ Form
+               => SnapForm m e v a     -- ^ Form
                -> String             -- ^ Form name
                -> m (Either v a)  -- ^ Result
 eitherSnapForm form name = do

--- a/examples/Snap.lhs
+++ b/examples/Snap.lhs
@@ -37,12 +37,12 @@ weights has the same length as the list of values.
 Now, we create a small form in which the user can enter a list (in Haskell
 syntax).
 
-> listForm :: (Read a, Show a) => [a] -> SnapForm Html BlazeFormHtml [a]
+> listForm :: (MonadSnap m, Read a, Show a) => [a] -> SnapForm m Html BlazeFormHtml [a]
 > listForm def = inputTextRead "Can't read list" (Just def) <++ errors
 
 We compose two of these forms to create a `WeightedSum` form:
 
-> weightedSumForm :: SnapForm Html BlazeFormHtml WeightedSum
+> weightedSumForm :: (MonadSnap m) => SnapForm m Html BlazeFormHtml WeightedSum
 > weightedSumForm = (`validate` equalSize) $ (<++ errors) $ WeightedSum
 >     <$> label "Weights: " ++> listForm [0.4, 0.4, 0.2]
 >     <*> label "Values: "  ++> listForm [64, 67, 91]


### PR DESCRIPTION
Change the type of eitherSnapForm to be more general.   This does make examples/Snap.hs slightly more ugly,  but before you couldn't use application-specific actions inside of Forms.
