### PR TITLE
Hey. digestive-functors-happstack needs a bump to the lastest happstack-server. No code changes, just the dependency range.

### DIFF
--- a/digestive-functors-happstack/digestive-functors-happstack.cabal
+++ b/digestive-functors-happstack/digestive-functors-happstack.cabal
@@ -19,7 +19,7 @@ Library
   Exposed-modules:   Text.Digestive.Forms.Happstack
   Build-depends:     base >= 4 && < 5,
                      digestive-functors == 0.1.0.*,
-                     happstack-server >= 6.0 && < 6.2,
+                     happstack-server >= 6.0 && < 6.3,
                      utf8-string >= 0.3,
                      bytestring >= 0.9,
                      text


### PR DESCRIPTION
digestive-functors-happstack: bumped upper bounds on happstack-server dependency
