### PR TITLE
Rename inputText to inputString, and add inputText which returns Text

### DIFF
--- a/digestive-functors-blaze/digestive-functors-blaze.cabal
+++ b/digestive-functors-blaze/digestive-functors-blaze.cabal
@@ -21,4 +21,5 @@ Library
   Build-depends:
     base               >= 4     && < 5,
     digestive-functors >= 0.1.0 && < 0.2,
-    blaze-html         >= 0.4   && < 0.6
+    blaze-html         >= 0.4   && < 0.6,
+    text               >= 0.11  && < 0.12

--- a/digestive-functors-blaze/src/Text/Digestive/Blaze/Html5.hs
+++ b/digestive-functors-blaze/src/Text/Digestive/Blaze/Html5.hs
@@ -21,6 +21,7 @@ module Text.Digestive.Blaze.Html5
 import Control.Monad (forM_, unless, when)
 import Data.Maybe (fromMaybe)
 import Data.Monoid (mempty)
+import Data.Text (Text)
 
 import Text.Blaze.Html5 (Html, (!), toValue, toHtml)
 import qualified Text.Blaze.Html5 as H
@@ -51,14 +52,22 @@ checked :: Bool -> Html -> Html
 checked False x = x
 checked True  x = x ! A.checked "checked"
 
-inputText :: (Monad m, Functor m, FormInput i f)
-          => Formlet m i e BlazeFormHtml String
-inputText = Forms.inputString $ \id' inp -> createFormHtml $ \cfg ->
+inputString :: (Monad m, Functor m, FormInput i f)
+            => Formlet m i e BlazeFormHtml String
+inputString = Forms.inputString $ \id' inp -> createFormHtml $ \cfg ->
     applyClasses' [htmlInputClasses] cfg $
         H.input ! A.type_ "text"
                 ! A.name (toValue $ show id')
                 ! A.id (toValue $ show id')
                 ! A.value (toValue $ fromMaybe "" inp)
+
+inputText :: (Monad m, Functor m, FormInput i f)
+          => Formlet m i e BlazeFormHtml Text
+inputText = Forms.inputText $ \id' inp -> createFormHtml $ \_ ->
+  H.input ! A.type_ "text"
+          ! A.name (toValue $ show id')
+          ! A.id (toValue $ show id')
+          ! A.value (toValue $ fromMaybe "" inp)
 
 inputHidden :: (Monad m, Functor m, FormInput i f)
             => Formlet m i e BlazeFormHtml String


### PR DESCRIPTION
See the discussion on #snapframework, between myself and stepcut:

 [10:19 PM] <stepcut> does your inputText use Text instead of String? or does it do something else ?
 [10:19 PM] <ocharles> path of least resistance :)
 [10:19 PM] <ocharles> stepcut: the former
 [10:19 PM] <stepcut> would be nice if the blaze-html library had inputString vs inputText
 [10:19 PM] <stepcut> someone should submit a patch ;)
 [10:19 PM] <ocharles> okokok, i'll submit it :)
 [10:20 PM] <ocharles> hrm, inputText is already taken though :/
 [10:20 PM] <stepcut> yeah
 [10:20 PM] <stepcut> and it doesn't return Text
 [10:20 PM] <stepcut> I think that is a bug ;)
 [10:20 PM] <ocharles> not too api breaking if I change that?
 [10:21 PM] <stepcut> I don't care if it breaks the API. Seems like the logical thing to do :p
 [10:21 PM] <stepcut> but I am not the maintainer, so...
 [10:21 PM] <ocharles> heh
 [10:21 PM] <ocharles> i'll see what jaspervdj says
 [10:22 PM] <stepcut> in my opinion, there are far too few people using digestive-functors today to worry about breaking a few apps. When millions of people are using it, do you want to have to explain that inputText returns a String instead of Text because we didn't want to break a few dozen projects with an easy to fix API change?
 [10:22 PM] <ocharles> especially when inputText in the main d-f package returns Text :)
