### PR TITLE
Loosen restriction on mtl to 1.1.

### DIFF
--- a/digestive-functors/digestive-functors.cabal
+++ b/digestive-functors/digestive-functors.cabal
@@ -35,5 +35,5 @@ Library
     base       >= 4       && < 5,
     bytestring >= 0.9,
     containers >= 0.3,
-    mtl        >= 2.0.0.0 && < 3,
+    mtl        >= 1.1.0.0 && < 3,
     text       >= 0.10


### PR DESCRIPTION
I don't know if this is a concern at this point, but digestive-functors works just fine with mtl-1.1, which I'm using in this project. I can maintain a separate ‘me’ branch for this if it's a bother to have this version without the instances that mtl2 added.
