### PR TITLE
Upgrade to work with Heist 0.10

### DIFF
--- a/digestive-functors-heist/digestive-functors-heist.cabal
+++ b/digestive-functors-heist/digestive-functors-heist.cabal
@@ -1,5 +1,5 @@
 Name:          digestive-functors-heist
-Version:       0.5.0.0
+Version:       0.5.1.0
 Synopsis:      Heist frontend for the digestive-functors library
 Description:   Heist frontend for the digestive-functors library
 Homepage:      http://github.com/jaspervdj/digestive-functors
@@ -19,6 +19,6 @@ Library
   Build-depends:
     base               >= 4    && < 5,
     digestive-functors >= 0.5  && < 0.6,
-    heist              >= 0.8  && < 0.9,
+    heist              >= 0.10 && < 0.11,
     text               >= 0.11 && < 0.12,
     xmlhtml            >= 0.1  && < 0.3

--- a/digestive-functors-heist/src/Text/Digestive/Heist.hs
+++ b/digestive-functors-heist/src/Text/Digestive/Heist.hs
@@ -57,7 +57,8 @@ import           Data.Maybe            (fromMaybe)
 import           Data.Monoid           (mappend)
 import           Data.Text             (Text)
 import qualified Data.Text             as T
-import           Text.Templating.Heist
+import           Heist
+import           Heist.Interpreted
 import qualified Text.XmlHtml          as X
 
 
@@ -106,7 +107,7 @@ makeElement name nodes = return . flip (X.Element name) nodes
 --------------------------------------------------------------------------------
 getRefAttributes :: Monad m
                  => Maybe Text                       -- ^ Optional default ref
-                 -> HeistT m (Text, [(Text, Text)])  -- ^ (Ref, other attrs)
+                 -> HeistT m m (Text, [(Text, Text)])  -- ^ (Ref, other attrs)
 getRefAttributes defaultRef = do
     node <- getParamNode
     return $ case node of
@@ -118,7 +119,7 @@ getRefAttributes defaultRef = do
 
 
 --------------------------------------------------------------------------------
-getContent :: Monad m => HeistT m [X.Node]
+getContent :: Monad m => HeistT m m [X.Node]
 getContent = liftM X.childNodes getParamNode
 
 
@@ -378,7 +379,7 @@ dfSubView view = do
     (ref, _) <- getRefAttributes Nothing
     content  <- getContent
     let view' = subView ref view
-    nodes <- localTS (bindDigestiveSplices view') $ runNodeList content
+    nodes <- localHS (bindDigestiveSplices view') $ runNodeList content
     return nodes
 
 


### PR DESCRIPTION
This is just a mindless port to make it build.  The magnitude of the changes
in Heist 0.10 really merit a deeper look to see how this package should be
changed to support compiled splices, but I don't have time for that right now.
I'm also a little unsure about the appropriate version bump.  Since the
external API is essentially unchanged, it seems like my minor version bump
might be ok, but I could also conceive of it causing problems.
