### PR TITLE
Bump up Heist version upper bound

### DIFF
--- a/digestive-functors-heist/digestive-functors-heist.cabal
+++ b/digestive-functors-heist/digestive-functors-heist.cabal
@@ -19,7 +19,7 @@ Library
   Build-depends:
     base               >= 4      && < 5,
     digestive-functors >= 0.6    && < 0.7,
-    heist              >= 0.10.2 && < 0.11,
+    heist              >= 0.10.2 && < 0.12,
     mtl                >= 2,
     text               >= 0.11   && < 0.12,
     xmlhtml            >= 0.1    && < 0.3


### PR DESCRIPTION
Snap-0.11.1 requires heist-0.11, so bump up the heist version upper
bound.  This also fixes the snap-extras package that doesn't currently
build with snap-0.11.1 due this problem.

See also https://github.com/ozataman/snap-extras/issues/2
