### PR TITLE
Heist: add wrapping div around label/input pairs for dfInputRadio

### DIFF
--- a/digestive-functors-heist/src/Text/Digestive/Heist.hs
+++ b/digestive-functors-heist/src/Text/Digestive/Heist.hs
@@ -258,15 +258,13 @@ dfInputRadio view = do
         value i  = ref' `mappend` "." `mappend` i
 
         makeOption (i, c, sel) =
-            [ X.Element "div"
-                [("class", "radio")]
-                [X.Element "input"
+            [ X.Element "label" [("for", value i)]
+              [ X.Element "input"
                   (attr sel ("checked", "checked") $ addAttrs attrs
                       [ ("type", "radio"), ("value", value i)
                       , ("id", value i), ("name", ref')
                       ]) []
-                , X.Element "label" [("for", value i)] [X.TextNode c]
-                ]
+              , X.TextNode c]
             ]
 
     return kids


### PR DESCRIPTION
The way the current code is, the labels / inputs are just sent out one after another, which makes it really hard to style, as you can't apply styling to the pairs as units, because the markup looks like:

```
<input ...>
<label ...>
<input ...>
<label ...>
...
```

So I added a `<div class="radio">` around each pair, so it looks like

```
<div class="radio">
    <input ...>
    <label ...>
</div>
<div class="radio">
    <input ...>
    <label ...>
</div>
...
```

Which can by styled as inline, if desired.
