### PR TITLE
Relaxed constrain on heist 0.12

### DIFF
--- a/digestive-functors-heist/digestive-functors-heist.cabal
+++ b/digestive-functors-heist/digestive-functors-heist.cabal
@@ -22,7 +22,7 @@ Library
     base               >= 4      && < 5,
     blaze-builder      >= 0.3    && < 0.4,
     digestive-functors >= 0.6    && < 0.7,
-    heist              >= 0.11.1 && < 0.12,
+    heist              >= 0.11.1 && < 0.13,
     mtl                >= 2      && < 2.2,
     text               >= 0.11   && < 0.12,
     xmlhtml            >= 0.1    && < 0.3


### PR DESCRIPTION
Hello Jasper,

now that heist 0.12 is out , we need to relax the constrain inside `digestive-functors-heist` to make it install correctly with the new snap ecosystem.
