### PR TITLE
The optional ref was broken

### DIFF
--- a/digestive-functors-heist/src/Text/Digestive/Heist/Compiled.hs
+++ b/digestive-functors-heist/src/Text/Digestive/Heist/Compiled.hs
@@ -416,7 +416,7 @@ dfIfChildErrors getView = do
     node <- getParamNode
     return $ yieldRuntime $ do
         view <- getView
-        let (ref, _) = getRefAttributes node Nothing
+        let (ref, _) = getRefAttributes node $ Just ""
         if null (childErrors ref view)
           then return mempty
           else return $ X.renderHtmlFragment X.UTF8 (X.childNodes node)


### PR DESCRIPTION
The docs state: "The ref attribute can be omitted if you want to check the entire form." This in fact was broken in compiled splices because a default ref of "" needs to be given.
