### PR TITLE
Adds better support for validation of optional fields.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -48,3 +48,4 @@ Contributors:
 - Oliver Charles
 - Ozgun Ataman
 - Toon Willems
+- [mavenraven.org](http://www.mavenraven.org/)

--- a/digestive-functors/src/Text/Digestive/Form.hs
+++ b/digestive-functors/src/Text/Digestive/Form.hs
@@ -46,6 +46,7 @@ module Text.Digestive.Form
     , check
     , checkM
     , validate
+    , validateOptional
     , validateM
     , disable
 
@@ -234,6 +235,20 @@ checkM err predicate form = validateM f form
 validate :: Monad m => (a -> Result v b) -> Form v m a -> Form v m b
 validate = validateM . (return .)
 
+--------------------------------------------------------------------------------
+-- | Same as 'validate', but works with forms of the form: Form v m (Maybe a).
+-- 
+--
+-- Example: taking the first character of an optional input string
+--
+-- > head' :: String -> Result String Char
+-- > head' []      = Error "Is empty"
+-- > head' (x : _) = Success x
+-- >
+-- > char :: Monad m => Form m String (Maybe Char)
+-- > char = validateOptional head' (optionalString Nothing)
+validateOptional :: Monad m => (a -> Result v b) -> Form v m (Maybe a) -> Form v m (Maybe b)
+validateOptional f = validate (forOptional f)
 
 --------------------------------------------------------------------------------
 -- | Version of 'validate' which allows monadic validations

--- a/digestive-functors/src/Text/Digestive/Form/Internal.hs
+++ b/digestive-functors/src/Text/Digestive/Form/Internal.hs
@@ -25,6 +25,7 @@ module Text.Digestive.Form.Internal
     , queryField
     , eval
     , formMapView
+    , forOptional
 
       -- * Debugging
     , debugFormPaths
@@ -381,6 +382,17 @@ formMapView f (Monadic x)    = formMapView f $ runIdentity x
 formMapView f (List d is)    = List (fmap (formMapView f) d) (formMapView f is)
 formMapView f (Metadata m x) = Metadata m $ formMapView f x
 
+
+--------------------------------------------------------------------------------
+-- | Combinator that lifts input and output of valiation function used by 'validate'
+-- to from (a -> Result v b) to (Maybe a -> Result v (Maybe b)).
+forOptional :: (a -> Result v b) -> Maybe a -> Result v (Maybe b)
+forOptional f x  = case (x) of
+    Nothing -> Success Nothing
+    Just x'  -> case (f x') of
+        Success x'' -> Success (Just x'')
+        Error   x'' -> Error x''
+         
 
 --------------------------------------------------------------------------------
 -- | Utility: bind for 'Result' inside another monad

--- a/digestive-functors/tests/Text/Digestive/View/Tests.hs
+++ b/digestive-functors/tests/Text/Digestive/View/Tests.hs
@@ -52,6 +52,21 @@ tests = testGroup "Text.Digestive.View.Tests"
         snd $ runIdentity $ postForm "f" floatForm $ testEnv
             [("f.f", "4.323")]
 
+    , testCase "validateOptional validated successfully" $ (@=?)
+        (Just (ValidateOptionalData (Just 8))) $
+        snd $ runIdentity $ postForm "f" validateOptionalForm $ testEnv
+            [("f.first_field", "8")]
+
+    , testCase "validateOptional allows nothing" $ (@=?)
+        (Just (ValidateOptionalData Nothing)) $
+        snd $ runIdentity $ postForm "f" validateOptionalForm $ testEnv
+            [("f.first_field", "")]
+
+    , testCase "validateOptional fails for invalid data" $ (@=?)
+        ["input must be even"] $
+        childErrors "" $ fst $ runIdentity $ postForm "f" validateOptionalForm $ testEnv
+            [("f.first_field", "9")]
+
     , testCase "Failing checkM" $ (@=?)
         ["This pokemon will not obey you!"] $
         childErrors "" $ fst $ runTrainerM $ postForm "f" pokemonForm $ testEnv


### PR DESCRIPTION
Adds "validateOptional" function. Its purpose is to be used in
conjuction with forms of the form: "Form v m (Maybe a)" e.g.
"optionalText" and "optionalString", so validators of the form (a -> Result v b)
can easily be chained. Internally, it uses the forOptional combinator.
