### PR TITLE
Fix stray text <1.1 upper bound

### DIFF
--- a/digestive-functors/digestive-functors.cabal
+++ b/digestive-functors/digestive-functors.cabal
@@ -63,7 +63,7 @@ Library
     containers >= 0.3     && < 0.6,
     mtl        >= 1.1.0.0 && < 3,
     old-locale >= 1.0     && < 1.1,
-    text       >= 0.10    && < 1.1,
+    text       >= 0.10    && < 1.2,
     time       >= 1.4     && < 1.5
 
 Test-suite digestive-functors-tests


### PR DESCRIPTION
Oops, my comment in issue #88 that the upper bound had already been fixed was wrong.  Here's a patch.  I've tested and it builds.
