### PR TITLE
[digestive-functors-heist] Bump heist upper bound

### DIFF
--- a/digestive-functors-heist/digestive-functors-heist.cabal
+++ b/digestive-functors-heist/digestive-functors-heist.cabal
@@ -25,7 +25,7 @@ Library
     base               >= 4      && < 5,
     blaze-builder      >= 0.3    && < 0.4,
     digestive-functors >= 0.6.1  && < 0.8,
-    heist              >= 0.13   && < 0.14,
+    heist              >= 0.13   && < 0.15,
     mtl                >= 2      && < 2.3,
     text               >= 0.11   && < 1.2,
     xmlhtml            >= 0.1    && < 0.3


### PR DESCRIPTION
Support 0.14.x. I've not tested this in practice so I don't know if we need other changes, but it _builds_ fine for me with this change.
