### PR TITLE
Update text dependency version bound up to 1.3, bump version 0.7.1.2

### DIFF
--- a/digestive-functors/CHANGELOG
+++ b/digestive-functors/CHANGELOG
@@ -1,3 +1,6 @@
+- 0.7.1.2
+    * Bump `text` dependency to allow up to `text-1.3`
+
 - 0.7.1.1
     * Bump `QuickCheck` dependency to allow `QuickCheck-2.7`
     * Clean warnings in tests compilation

--- a/digestive-functors/digestive-functors.cabal
+++ b/digestive-functors/digestive-functors.cabal
@@ -1,5 +1,5 @@
 Name:     digestive-functors
-Version:  0.7.1.1
+Version:  0.7.1.2
 Synopsis: A practical formlet library
 
 Description:
@@ -98,7 +98,7 @@ Test-suite digestive-functors-tests
     containers >= 0.3     && < 0.6,
     mtl        >= 1.1.0.0 && < 3,
     old-locale >= 1.0     && < 1.1,
-    text       >= 0.10    && < 1.2,
+    text       >= 0.10    && < 1.3,
     time       >= 1.4     && < 1.5
 
 Source-repository head


### PR DESCRIPTION
Hi! 

Text package had a minor version update. It would be great to have updated .cabal dependency to reduce chance of cabal hell(like I have when I try to use digestive-functors-aeson). 
