### PR TITLE
Relax version bounds on text dependency

### DIFF
--- a/digestive-functors-blaze/digestive-functors-blaze.cabal
+++ b/digestive-functors-blaze/digestive-functors-blaze.cabal
@@ -21,4 +21,4 @@ Library
     blaze-html         >= 0.5  && < 0.8,
     blaze-markup       >= 0.5  && < 0.7,
     digestive-functors >= 0.6  && < 0.8,
-    text               >= 0.11 && < 1.2
+    text               >= 0.11 && < 1.3

--- a/digestive-functors-snap/digestive-functors-snap.cabal
+++ b/digestive-functors-snap/digestive-functors-snap.cabal
@@ -21,7 +21,7 @@ Library
     containers         >= 0.3  && < 0.6,
     digestive-functors >= 0.7  && < 0.8,
     snap-core          >= 0.7  && < 0.10,
-    text               >= 0.11 && < 1.2,
+    text               >= 0.11 && < 1.3,
     directory          >= 1.0  && < 1.4,
     filepath           >= 1.0  && < 1.4,
     mtl                >= 2    && < 3,


### PR DESCRIPTION
The current version bound prevents us from having a consistent set of dependencies (since we have other dependencies that require text >= 1.2). Everything seems to work fine with 1.2.0.4.