### PR TITLE
Add support for a list of files via <input type="file" multiple />

### DIFF
--- a/digestive-functors-heist/src/Text/Digestive/Heist.hs
+++ b/digestive-functors-heist/src/Text/Digestive/Heist.hs
@@ -299,9 +299,8 @@ dfInputFile :: Monad m => View Text -> Splice m
 dfInputFile view = do
     (ref, attrs) <- getRefAttributes Nothing
     let ref'  = absoluteRef ref view
-        value = maybe "" T.pack $ fieldInputFile ref view
     return $ makeElement "input" [] $ addAttrs attrs $ setDisabled ref view
-        [("type", "file"), ("id", ref'), ("name", ref'), ("value", value)]
+        [("type", "file"), ("id", ref'), ("name", ref')]
 
 
 --------------------------------------------------------------------------------

--- a/digestive-functors-heist/src/Text/Digestive/Heist/Compiled.hs
+++ b/digestive-functors-heist/src/Text/Digestive/Heist/Compiled.hs
@@ -336,10 +336,8 @@ dfInputCheckbox = dfMaster $ \ref attrs view -> do
 dfInputFile :: Monad m => RuntimeSplice m (View v) -> Splice m
 dfInputFile = dfMaster $ \ref attrs view -> do
     let ref'  = absoluteRef ref view
-        value = maybe "" T.pack $ fieldInputFile ref view
         e = makeElement "input" [] $ addAttrs attrs $
-            [ ("type", "file"), ("id", ref')
-            , ("name", ref'), ("value", value)]
+            [("type", "file"), ("id", ref'), ("name", ref')]
     return $ X.renderHtmlFragment X.UTF8 e
 
 

--- a/digestive-functors/src/Text/Digestive/Form.hs
+++ b/digestive-functors/src/Text/Digestive/Form.hs
@@ -27,6 +27,7 @@ module Text.Digestive.Form
     , groupedChoiceWith'
     , bool
     , file
+    , fileMultiple
 
       -- * Optional forms
     , optionalText
@@ -64,7 +65,7 @@ module Text.Digestive.Form
 import           Control.Applicative
 import           Control.Monad                      (liftM, liftM2)
 import           Data.List                          (findIndex)
-import           Data.Maybe                         (fromMaybe)
+import           Data.Maybe                         (fromMaybe, listToMaybe)
 import           Data.Monoid                        (Monoid)
 import           Data.Text                          (Text)
 import qualified Data.Text                          as T
@@ -203,7 +204,15 @@ bool = Pure . Bool . fromMaybe False
 --------------------------------------------------------------------------------
 -- | Returns a 'Formlet' for file selection
 file :: (Monad m, Monoid v) => Form v m (Maybe FilePath)
-file = Pure File
+file = listToMaybe <$> Pure File
+
+
+--------------------------------------------------------------------------------
+-- | Returns a 'Formlet' for multiple file selection.  Intended for use with
+-- the @multiple@ attribute, which allows for multiple files to be uploaded
+-- with a single input element.
+fileMultiple :: (Monad m, Monoid v) => Form v m [FilePath]
+fileMultiple = Pure File
 
 
 --------------------------------------------------------------------------------

--- a/digestive-functors/src/Text/Digestive/Form/Internal/Field.hs
+++ b/digestive-functors/src/Text/Digestive/Form/Internal/Field.hs
@@ -14,7 +14,7 @@ module Text.Digestive.Form.Internal.Field
 
 --------------------------------------------------------------------------------
 import           Control.Arrow        (second)
-import           Data.Maybe           (fromMaybe, listToMaybe)
+import           Data.Maybe           (fromMaybe, listToMaybe, mapMaybe)
 import           Data.Text            (Text)
 
 
@@ -32,7 +32,7 @@ data Field v a where
     -- the list.
     Choice    :: [(Text, [(Text, (a, v))])] -> Int -> Field v (a, Int)
     Bool      :: Bool -> Field v Bool
-    File      :: Field v (Maybe FilePath)
+    File      :: Field v [FilePath]
 
 
 --------------------------------------------------------------------------------
@@ -73,8 +73,11 @@ evalField _    _                 (Choice ls' x) =
 evalField Get  _                 (Bool x)      = x
 evalField Post (TextInput x : _) (Bool _)      = x == "on"
 evalField Post _                 (Bool _)      = False
-evalField Post (FileInput x : _) File          = Just x
-evalField _    _                 File          = Nothing
+evalField Post xs                File          = mapMaybe maybeFile xs
+  where
+    maybeFile (FileInput x) = Just x
+    maybeFile _             = Nothing
+evalField _    _                 File          = []
 
 
 --------------------------------------------------------------------------------

--- a/digestive-functors/src/Text/Digestive/View.hs
+++ b/digestive-functors/src/Text/Digestive/View.hs
@@ -260,14 +260,14 @@ fieldInputBool ref (View _ _ form input _ method) =
 
 --------------------------------------------------------------------------------
 -- | Return the FilePath referred to by the given serialized path, if set.
-fieldInputFile :: forall v. Text -> View v -> Maybe FilePath
+fieldInputFile :: forall v. Text -> View v -> [FilePath]
 fieldInputFile ref (View _ _ form input _ method) =
     queryField path form eval'
   where
     path       = toPath ref
     givenInput = lookupInput path input
 
-    eval' :: Field v b -> Maybe FilePath
+    eval' :: Field v b -> [FilePath]
     eval' field = case field of
         File -> evalField method givenInput File
         f    -> error $ T.unpack ref ++ ": expected (File), " ++


### PR DESCRIPTION
This also fixes a validation error in digestive-functors-heist (the 'value' attribute is not valid on file inputs).  Fixes https://github.com/jaspervdj/digestive-functors/issues/124