### PR TITLE
Heist 1.0.0 Support

### DIFF
--- a/digestive-functors-heist/digestive-functors-heist.cabal
+++ b/digestive-functors-heist/digestive-functors-heist.cabal
@@ -25,7 +25,8 @@ Library
     base               >= 4    && < 5,
     blaze-builder      >= 0.3  && < 0.5,
     digestive-functors >= 0.8  && < 0.9,
-    heist              >= 0.13 && < 0.15,
+    heist              >= 0.13 && < 1.1,
+    map-syntax         >= 0.2  && < 0.3,
     mtl                >= 2    && < 2.3,
     text               >= 0.11 && < 1.3,
     xmlhtml            >= 0.1  && < 0.3

--- a/digestive-functors-heist/src/Text/Digestive/Heist.hs
+++ b/digestive-functors-heist/src/Text/Digestive/Heist.hs
@@ -57,6 +57,7 @@ import           Control.Monad         (liftM, mplus)
 import           Control.Monad.Trans
 import           Data.Function         (on)
 import           Data.List             (unionBy)
+import           Data.Map.Syntax       ((##))
 import           Data.Maybe            (fromMaybe)
 import           Data.Monoid           (mappend)
 import           Data.Text             (Text)

--- a/digestive-functors-heist/src/Text/Digestive/Heist/Compiled.hs
+++ b/digestive-functors-heist/src/Text/Digestive/Heist/Compiled.hs
@@ -61,6 +61,7 @@ import           Control.Monad            (mplus)
 import           Control.Monad.Trans      (MonadIO, liftIO)
 import           Data.Function            (on)
 import           Data.List                (unionBy)
+import           Data.Map.Syntax          ((##))
 import           Data.Monoid              (mappend, mconcat, mempty, (<>))
 import           Data.Text                (Text)
 import qualified Data.Text                as T

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,8 @@
-resolver: lts-5.10
-extra-deps: []
-flags: {}
-extra-package-dbs: []
+resolver: lts-7.15
+
+extra-deps:
+  - heist-1.0.1.0
+  - map-syntax-0.2.0.1
 
 packages:
   - digestive-functors/


### PR DESCRIPTION
Adds Heist 1.0.0 support, bumps stack LTS to 7.15.
Adds the newly seperated package map-syntax as a dependency.