### PR TITLE
Remove path information from Choice input element values

### DIFF
--- a/digestive-functors-blaze/src/Text/Digestive/Blaze/Html5.hs
+++ b/digestive-functors-blaze/src/Text/Digestive/Blaze/Html5.hs
@@ -20,8 +20,7 @@ module Text.Digestive.Blaze.Html5
 
 --------------------------------------------------------------------------------
 import           Control.Monad               (forM_, when)
-import           Data.Maybe                  (fromMaybe)
-import           Data.Monoid                 (mappend, mempty)
+import           Data.Monoid                 (mempty)
 import           Data.Text                   (Text)
 import           Text.Blaze.Html             (Html, (!))
 import qualified Text.Blaze.Html5            as H
@@ -96,12 +95,11 @@ inputSelect ref view = H.select
     ! A.id    (H.toValue ref')
     ! A.name  (H.toValue ref')
     $ forM_ choices $ \(i, c, sel) -> H.option
-        !  A.value (value i)
+        !  A.value (H.toValue i)
         !? (sel, A.selected "selected")
         $ c
   where
     ref'    = absoluteRef ref view
-    value i = H.toValue ref' `mappend` "." `mappend` H.toValue i
     choices = fieldInputChoice ref view
 
 
@@ -111,14 +109,13 @@ inputRadio :: Bool       -- ^ Add @br@ tags?
            -> View Html  -- ^ View
            -> Html       -- ^ Resulting HTML
 inputRadio brs ref view = forM_ choices $ \(i, c, sel) -> do
-    let val = value i
+    let val = H.toValue i
     H.input ! A.type_ "radio" ! A.value val ! A.id val ! A.name (H.toValue ref')
         !? (sel, A.checked "checked")
     H.label ! A.for val $ c
     when brs H.br
   where
     ref'    = absoluteRef ref view
-    value i = H.toValue ref' `mappend` "." `mappend` H.toValue i
     choices = fieldInputChoice ref view
 
 

--- a/digestive-functors-heist/src/Text/Digestive/Heist.hs
+++ b/digestive-functors-heist/src/Text/Digestive/Heist.hs
@@ -59,7 +59,6 @@ import           Data.Function         (on)
 import           Data.List             (unionBy)
 import           Data.Map.Syntax       ((##))
 import           Data.Maybe            (fromMaybe)
-import           Data.Monoid           (mappend)
 import           Data.Text             (Text)
 import qualified Data.Text             as T
 import           Heist
@@ -220,10 +219,9 @@ dfInputSelect view = do
     let ref'     = absoluteRef ref view
         choices  = fieldInputChoice ref view
         kids     = map makeOption choices
-        value i  = ref' `mappend` "." `mappend` i
 
         makeOption (i, c, sel) = X.Element "option"
-            (attr sel ("selected", "selected") [("value", value i)])
+            (attr sel ("selected", "selected") [("value", i)])
             [X.TextNode c]
 
     return $ makeElement "select" kids $ addAttrs attrs $ setDisabled ref view
@@ -240,12 +238,11 @@ dfInputSelectGroup view = do
     let ref'     = absoluteRef ref view
         choices  = fieldInputChoiceGroup ref view
         kids     = map makeGroup choices
-        value i  = ref' `mappend` "." `mappend` i
 
         makeGroup (name, options) = X.Element "optgroup"
             [("label", name)] $ map makeOption options
         makeOption (i, c, sel) = X.Element "option"
-            (attr sel ("selected", "selected") [("value", value i)])
+            (attr sel ("selected", "selected") [("value", i)])
             [X.TextNode c]
 
     return $ makeElement "select" kids $ addAttrs attrs $ setDisabled ref view
@@ -263,14 +260,13 @@ dfInputRadio view = do
     let ref'     = absoluteRef ref view
         choices  = fieldInputChoice ref view
         kids     = concatMap makeOption choices
-        value i  = ref' `mappend` "." `mappend` i
 
         makeOption (i, c, sel) =
-            [ X.Element "label" [("for", value i)]
+            [ X.Element "label" [("for", i)]
               [ X.Element "input"
                   (attr sel ("checked", "checked") $ addAttrs attrs
-                      [ ("type", "radio"), ("value", value i)
-                      , ("id", value i), ("name", ref')
+                      [ ("type", "radio"), ("value", i)
+                      , ("id", i), ("name", ref')
                       ]) []
               , X.TextNode c]
             ]

--- a/digestive-functors-heist/src/Text/Digestive/Heist/Compiled.hs
+++ b/digestive-functors-heist/src/Text/Digestive/Heist/Compiled.hs
@@ -351,10 +351,9 @@ dfInputSelect = dfMaster $ \ref attrs view -> do
     let ref'     = absoluteRef ref view
         choices  = fieldInputChoice ref view
         kids     = map makeOption choices
-        value i  = ref' <> "." <> i
 
         makeOption (i, c, sel) = X.Element "option"
-            (attr sel ("selected", "selected") [("value", value i)])
+            (attr sel ("selected", "selected") [("value", i)])
             [X.TextNode c]
 
         e = makeElement "select" kids $ addAttrs attrs
@@ -371,12 +370,11 @@ dfInputSelectGroup = dfMaster $ \ref attrs view -> do
     let ref'     = absoluteRef ref view
         choices  = fieldInputChoiceGroup ref view
         kids     = map makeGroup choices
-        value i  = ref' <> "." <> i
 
         makeGroup (name, options) = X.Element "optgroup"
             [("label", name)] $ map makeOption options
         makeOption (i, c, sel) = X.Element "option"
-            (attr sel ("selected", "selected") [("value", value i)])
+            (attr sel ("selected", "selected") [("value", i)])
             [X.TextNode c]
 
         e = makeElement "select" kids $ addAttrs attrs
@@ -393,15 +391,14 @@ dfInputRadio = dfMaster $ \ref attrs view -> do
     let ref'     = absoluteRef ref view
         choices  = fieldInputChoice ref view
         kids     = concatMap makeOption choices
-        value i  = ref' <> "." <> i
 
         makeOption (i, c, sel) =
             [ X.Element "input"
                 (attr sel ("checked", "checked") $ addAttrs attrs
-                    [ ("type", "radio"), ("value", value i)
-                    , ("id", value i), ("name", ref')
+                    [ ("type", "radio"), ("value", i)
+                    , ("id", i), ("name", ref')
                     ]) []
-            , X.Element "label" [("for", value i)] [X.TextNode c]
+            , X.Element "label" [("for", i)] [X.TextNode c]
             ]
 
     return $ X.renderHtmlFragment X.UTF8 kids

--- a/digestive-functors/tests/Text/Digestive/View/Tests.hs
+++ b/digestive-functors/tests/Text/Digestive/View/Tests.hs
@@ -38,8 +38,8 @@ tests = testGroup "Text.Digestive.View.Tests"
             [ ("f.name",     "charmander")
             , ("f.level",    "5")
             , ("f.type",     "type.1")
-            , ("f.weakness", "weakness.0")
-            , ("f.weakness", "weakness.3")
+            , ("f.weakness", "0") -- NOTE: this is the newer style of Choice values
+            , ("f.weakness", "3")
             ]
 
     , testCase "optional unspecified" $ (@=?)
@@ -47,7 +47,7 @@ tests = testGroup "Text.Digestive.View.Tests"
         snd $ runTrainerM $ postForm "f" pokemonForm $ testEnv
             [ ("f.name",     "magmar")
             , ("f.type",     "type.1")
-            , ("f.weakness", "weakness.0")
+            , ("f.weakness", "weakness.0") -- NOTE: this is the older style of Choice values
             , ("f.weakness", "weakness.3")
             ]
 


### PR DESCRIPTION
* Remove path information from the values of Choice input types in both of the Heist and Blaze packages
* Allows the values of Choice input types to contain '.' characters in cases where the submitted value is an exact match to the choice values (eg. `my-file.jpg' will successfully lookup the correct index in a choice list of `[("my-file.jpg", ("my-file.jpg", "my-file.jpg")), ("your-file.jpg", ("your-file.jpg", "your-file.jpg"))]`.  The older style of submitted values that contain the path information continue to work.

Fully resolves https://github.com/jaspervdj/digestive-functors/issues/38