### PR TITLE
Bump version ranges for blaze-html and blaze-markup

### DIFF
--- a/digestive-functors-blaze/digestive-functors-blaze.cabal
+++ b/digestive-functors-blaze/digestive-functors-blaze.cabal
@@ -21,7 +21,7 @@ Library
 
   Build-depends:
     base               >= 4    && < 5,
-    blaze-html         >= 0.5  && < 0.9,
-    blaze-markup       >= 0.5  && < 0.8,
+    blaze-html         >= 0.5  && < 0.10,
+    blaze-markup       >= 0.5  && < 0.9,
     digestive-functors >= 0.8  && < 0.9,
     text               >= 0.11 && < 1.3


### PR DESCRIPTION
I've tested that it compiles with the latest `blaze-html-0.9.0.1` and `blaze-markup-0.8.0.0`.