### PR TITLE
Fix returned value for choice forms when no value is submitted

### DIFF
--- a/digestive-functors/src/Text/Digestive/Form.hs
+++ b/digestive-functors/src/Text/Digestive/Form.hs
@@ -146,12 +146,10 @@ choiceWith items def = choiceWith' items def'
 choiceWith'
     :: (Monad m, Monoid v) => [(Text, (a, v))] -> Maybe Int -> Form v m a
 choiceWith' []    _   = error "choice expects a list with at least one item in it"
-choiceWith' items def = fromMaybe defaultItem . listToMaybe . map fst <$> (Pure $ Choice [("", items)] def')
+choiceWith' items def = fromMaybe defaultItem . listToMaybe . map fst <$> (Pure $ Choice [("", items)] [def'])
   where
-    defaultItem = fst $ snd $ head items
-    def' = case def of
-      Just x  -> [x]
-      Nothing -> [0]
+    defaultItem = fst $ snd $ items !! def'
+    def' = fromMaybe 0 def
 
 
 --------------------------------------------------------------------------------
@@ -187,9 +185,7 @@ choiceWithMultiple'
     :: (Monad m, Monoid v) => [(Text, (a, v))] -> Maybe [Int] -> Form v m [a]
 choiceWithMultiple' items def = map fst <$> (Pure $ Choice [("", items)] def')
   where
-    def' = case def of
-      Just x  -> x
-      Nothing -> []
+    def' = fromMaybe [] def
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
 It correctly falls back to default value (or the first element in the list of choices when no default is provided).  Fixes regression caused by commit 594758597f6888e3828e133e17fd5f398d94d765