### PR TITLE
Update digestive-functors-happstack.cabal

### DIFF
--- a/digestive-functors-happstack/digestive-functors-happstack.cabal
+++ b/digestive-functors-happstack/digestive-functors-happstack.cabal
@@ -19,7 +19,7 @@ Library
 
   Build-depends:
     base                  >= 4    && < 5,
-    bytestring            >= 0.9  && < 0.11,
+    bytestring            >= 0.9  && < 0.12,
     digestive-functors    >= 0.8  && < 0.9,
     happstack-server      >= 6.0  && < 7.7,
-    text                  >= 0.11 && < 1.3
+    text                  >= 0.11 && < 2.1


### PR DESCRIPTION
allow bytestring-0.11 and text-2.0